### PR TITLE
Add hardcoded comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -23,6 +23,11 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -31,7 +31,7 @@ import com.google.gson.GsonBuilder;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/commentsData")
 public class DataServlet extends HttpServlet {
-  private static final List<String> comments = Collections.unmodifiableList(Arrays.asList(
+  private static final List<String> COMMENTS = Collections.unmodifiableList(Arrays.asList(
     "That's an interesting website you got here",
     "Maybe you could post a link to your youtube channel??",
     "А мне вот интересно: работает ли юникод корректно?",
@@ -48,7 +48,7 @@ public class DataServlet extends HttpServlet {
     builder.disableHtmlEscaping();
 
     Gson gson = builder.create();
-    String json = gson.toJson(comments);
+    String json = gson.toJson(COMMENTS);
     response.getWriter().write(json);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -16,6 +16,7 @@ package com.google.sps.servlets;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
@@ -29,16 +30,13 @@ import com.google.gson.GsonBuilder;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/commentsData")
 public class DataServlet extends HttpServlet {
-  private static List<String> comments;
-  
-  static {
-    comments = new ArrayList<>();
-    comments.add("That's an interesting website you got here");
-    comments.add("Maybe you could post a link to your youtube channel??");
-    comments.add("А мне вот интересно: работает ли юникод корректно?");
-    comments.add("And what if I use characters outside of 𝔹𝕄ℙ? 😳");
-    comments.add("<img src=x onerror=alert(1)>");
-  }
+  private static final List<String> comments = Arrays.asList(
+    "That's an interesting website you got here",
+    "Maybe you could post a link to your youtube channel??",
+    "А мне вот интересно: работает ли юникод корректно?",
+    "And what if I use characters outside of 𝔹𝕄ℙ? 😳",
+    "<img src=x onerror=alert(1)>"
+  );
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -21,12 +21,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
-@WebServlet("/data")
+@WebServlet("/commentsData")
 public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("<h1>Hello world!</h1>");
+    response.setContentType("text/plain;");
+    response.getWriter().println("Hello, Nikita!");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
@@ -30,13 +31,13 @@ import com.google.gson.GsonBuilder;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/commentsData")
 public class DataServlet extends HttpServlet {
-  private static final List<String> comments = Arrays.asList(
+  private static final List<String> comments = Collections.unmodifiableList(Arrays.asList(
     "That's an interesting website you got here",
     "Maybe you could post a link to your youtube channel??",
     "А мне вот интересно: работает ли юникод корректно?",
     "And what if I use characters outside of 𝔹𝕄ℙ? 😳",
     "<img src=x onerror=alert(1)>"
-  );
+  ));
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,18 +15,41 @@
 package com.google.sps.servlets;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/commentsData")
 public class DataServlet extends HttpServlet {
+  private static List<String> comments;
+  
+  static {
+    comments = new ArrayList<>();
+    comments.add("That's an interesting website you got here");
+    comments.add("Maybe you could post a link to your youtube channel??");
+    comments.add("А мне вот интересно: работает ли юникод корректно?");
+    comments.add("And what if I use characters outside of 𝔹𝕄ℙ? 😳");
+    comments.add("<img src=x onerror=alert(1)>");
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/plain;");
-    response.getWriter().println("Hello, Nikita!");
+    response.setCharacterEncoding("UTF-8");
+    response.setContentType("text/json");
+
+    GsonBuilder builder = new GsonBuilder();
+    builder.disableHtmlEscaping();
+
+    Gson gson = builder.create();
+    String json = gson.toJson(comments);
+    response.getWriter().write(json);
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -10,7 +10,7 @@
   <script src="script.js"></script>
 </head>
 
-<body>
+<body onload="loadComments()">
   <div class="navbar">
     <a href="#about">About me</a>
     <a href="#projects">Projects</a>
@@ -127,6 +127,13 @@
       <li><a href="https://vk.com/tsarn">VK</a></li>
       <li><a href="https://github.com/tsarn">GitHub</a></li>
     </ul>
+
+    <hr />
+
+    Leave a comment!
+
+    <div class="comments" id="comments">
+    </div>
   </div>
 </body>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -130,7 +130,7 @@
 
     <hr />
 
-    Leave a comment!
+    <h3>Leave a comment!</h3>
 
     <div class="comments" id="comments">
     </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -47,5 +47,11 @@ function makeImagesClickable() {
 async function loadComments() {
     const comments = await fetch("/commentsData");
     const container = document.getElementById("comments");
-    container.innerText = await comments.text();
+    container.innerHTML = "";
+
+    for (const comment of await comments.json()) {
+        const element = document.createElement("p");
+        element.innerText = comment;
+        container.appendChild(element);
+    }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -40,3 +40,12 @@ function makeImagesClickable() {
         });
     }
 }
+
+/*
+ * Fetch comments from server and display them in #comments
+ */
+async function loadComments() {
+    const comments = await fetch("/commentsData");
+    const container = document.getElementById("comments");
+    container.innerText = await comments.text();
+}


### PR DESCRIPTION
Endpoint returns comments in JSON format (using `gson` library). Client fetches it using `fetch` API. Unicode works, simple XSS attacks don't.